### PR TITLE
chore: support LatencySecond field

### DIFF
--- a/src/__tests__/event.ts
+++ b/src/__tests__/event.ts
@@ -33,7 +33,6 @@ const INTERNAL_SDK_ERROR_METRICS_EVENT_NAME =
   'type.googleapis.com/bucketeer.event.client.InternalSdkErrorMetricsEvent';
 const TIMEOUT_ERROR_METRICS_EVENT_NAME =
   'type.googleapis.com/bucketeer.event.client.TimeoutErrorMetricsEvent';
-const DURATION_NAME = 'type.googleapis.com/google.protobuf.Duration';
 
 const tag = 'tag';
 const goalId = 'goalId';
@@ -54,7 +53,7 @@ const id = 'id';
 const featureVersion = 7;
 const variationId = 'vid';
 const variationValue = 'value';
-const durationMS = new Date(2000, 1, 2).getTime() - new Date(2000, 1, 2).getTime();
+const second = (new Date(2000, 1, 2).getTime() - new Date(2000, 1, 2).getTime()) / 1000;
 const sizeByte = 1000;
 const apiId = ApiId.GET_EVALUATION;
 
@@ -125,16 +124,13 @@ test('createDefaultEvaluationEvent', (t) => {
 test('createLatencyMetricsEvent', (t) => {
   const getEvaluationLatencyMetricsEvent: LatencyMetricsEvent = {
     apiId,
-    duration: {
-      value: convertMS(durationMS),
-      '@type': DURATION_NAME,
-    },
+    latencySecond: second,
     labels: {
       tag,
     },
     '@type': LATENCY_METRICS_EVENT_NAME,
   };
-  const actual = createLatencyMetricsEvent(tag, durationMS, apiId);
+  const actual = createLatencyMetricsEvent(tag, second, apiId);
   const metrics = JSON.parse(actual.event);
   t.deepEqual(JSON.parse(metrics.event), getEvaluationLatencyMetricsEvent);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,13 +155,13 @@ export function initialize(config: Config): Bucketeer {
     registerEvents();
   }
 
-  function saveEvaluationMetricsEvent(tag: string, durationMS: number, size: number) {
-    saveLatencyMetricsEvent(tag, durationMS, ApiId.GET_EVALUATION);
+  function saveEvaluationMetricsEvent(tag: string, second: number, size: number) {
+    saveLatencyMetricsEvent(tag, second, ApiId.GET_EVALUATION);
     saveSizeMetricsEvent(tag, size, ApiId.GET_EVALUATION);
   }
 
-  function saveLatencyMetricsEvent(tag: string, durationMS: number, apiId: NodeApiIds) {
-    eventStore.add(createLatencyMetricsEvent(tag, durationMS, apiId));
+  function saveLatencyMetricsEvent(tag: string, second: number, apiId: NodeApiIds) {
+    eventStore.add(createLatencyMetricsEvent(tag, second, apiId));
     registerEvents();
   }
 
@@ -293,10 +293,10 @@ export function initialize(config: Config): Bucketeer {
         saveDefaultEvaluationEvent(user, featureId);
         return defaultValue;
       }
-      const durationMS: number = Date.now() - startTime;
+      const second = (Date.now() - startTime) / 1000;
       const size = lengthInUtf8Bytes(JSON.stringify(res));
       saveEvaluationEvent(user, evaluation);
-      saveEvaluationMetricsEvent(tag, durationMS, size);
+      saveEvaluationMetricsEvent(tag, second, size);
       return evaluation.variationValue;
     },
     async getBoolVariation(user: User, featureId: string, defaultValue: boolean): Promise<boolean> {

--- a/src/objects/duration.ts
+++ b/src/objects/duration.ts
@@ -1,6 +1,0 @@
-export const DURATION_NAME = 'type.googleapis.com/google.protobuf.Duration';
-
-export type Duration = {
-  value: string;
-  '@type': typeof DURATION_NAME;
-};

--- a/src/objects/metricsEvent.ts
+++ b/src/objects/metricsEvent.ts
@@ -1,6 +1,5 @@
 import { createTimestamp } from '../utils/time';
 import { ApiId, NodeApiIds } from './apiId';
-import { Duration, DURATION_NAME } from './duration';
 import { createEvent } from './event';
 import { SourceId } from './sourceId';
 
@@ -54,7 +53,7 @@ export type SizeMetricsEvent = {
 
 export type LatencyMetricsEvent = {
   apiId: ApiId.GET_EVALUATION | ApiId.REGISTER_EVENTS;
-  duration: Duration;
+  latencySecond: number;
   labels: { [key: string]: string };
   '@type': typeof LATENCY_METRICS_EVENT_NAME;
 };
@@ -113,13 +112,10 @@ export function createMetricsEvent(b: string): MetricsEvent {
   };
 }
 
-export function createLatencyMetricsEvent(tag: string, durationMS: number, apiId: NodeApiIds) {
+export function createLatencyMetricsEvent(tag: string, second: number, apiId: NodeApiIds) {
   const getEvaluationLatencyMetricsEvent: LatencyMetricsEvent = {
     apiId,
-    duration: {
-      value: convertMS(durationMS),
-      '@type': DURATION_NAME,
-    },
+    latencySecond: second,
     labels: {
       tag,
     },

--- a/src/objects/status.ts
+++ b/src/objects/status.ts
@@ -1,6 +1,5 @@
 import { createTimestamp } from '../utils/time';
 import { ApiId, NodeApiIds } from './apiId';
-import { Duration, DURATION_NAME } from './duration';
 import { createEvent } from './event';
 import { createMetricsEvent } from './metricsEvent';
 import { SourceId } from './sourceId';


### PR DESCRIPTION
We currently use LatencySecond field instead of Duration field. See https://github.com/bucketeer-io/bucketeer/commit/1a7d7ad9e6b988056eeeee70cce8bb8a062fc0dc.