### PR TITLE
chore: add the source ID and sdk version to the register events API 

### DIFF
--- a/src/__tests__/api_success.ts
+++ b/src/__tests__/api_success.ts
@@ -62,7 +62,7 @@ test.before((t) => {
             t.is(jsonBody.sdkVersion, version);
             t.is(jsonBody.sourceId, SourceId.NODE_SERVER);
           } catch (error) {
-            t.fail('Invalid JSON or data structure ');
+            t.fail('Invalid JSON or data structure');
           }
           switch (req.url) {
             case evaluationAPI:

--- a/src/__tests__/api_success.ts
+++ b/src/__tests__/api_success.ts
@@ -58,7 +58,7 @@ test.before((t) => {
         req.on('end', () => {
           try {
             let jsonBody = JSON.parse(body) as BaseRequest;
-            // Verify the request needs to inclued `sdkVersion` and `sourceId`
+            // Verify the request needs to include `sdkVersion` and `sourceId`
             t.is(jsonBody.sdkVersion, version);
             t.is(jsonBody.sourceId, SourceId.NODE_SERVER);
           } catch (error) {

--- a/src/__tests__/request.ts
+++ b/src/__tests__/request.ts
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('request should containt source_id', async (t) => {
+  t.true(true);
+});

--- a/src/__tests__/request.ts
+++ b/src/__tests__/request.ts
@@ -1,5 +1,0 @@
-import test from 'ava';
-
-test('request should containt source_id', async (t) => {
-  t.true(true);
-});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,6 +4,7 @@ import { Event } from '../objects/event';
 import { SourceId } from '../objects/sourceId';
 import { GetEvaluationRequest, RegisterEventsRequest } from '../objects/request';
 import { GetEvaluationResponse, RegisterEventsResponse } from '../objects/response';
+import { version } from '../objects/version';
 
 const scheme = 'https://';
 const evaluationAPI = '/get_evaluation';
@@ -28,6 +29,7 @@ export class Client {
       user,
       featureId,
       sourceId: SourceId.NODE_SERVER,
+      sdkVersion: version,
     };
     const chunk = JSON.stringify(req);
     const url = scheme.concat(this.host, evaluationAPI);
@@ -50,6 +52,8 @@ export class Client {
   registerEvents(events: Array<Event>): Promise<[RegisterEventsResponse, number]> {
     const req: RegisterEventsRequest = {
       events,
+      sdkVersion: version,
+      sourceId: SourceId.NODE_SERVER,
     };
     const chunk = JSON.stringify(req);
     const url = scheme.concat(this.host, eventsAPI);

--- a/src/objects/evaluationEvent.ts
+++ b/src/objects/evaluationEvent.ts
@@ -4,7 +4,7 @@ import { Event, createEvent } from './event';
 import { Reason, ReasonType } from './reason';
 import { SourceId } from './sourceId';
 import { User } from './user';
-const version: string = require('../../package.json').version;
+import { version } from './version';
 
 const EVALUATION_EVENT_NAME = 'type.googleapis.com/bucketeer.event.client.EvaluationEvent';
 

--- a/src/objects/request.ts
+++ b/src/objects/request.ts
@@ -4,6 +4,8 @@ import { User } from './user';
 
 export type RegisterEventsRequest = {
   events: Event[];
+  sdkVersion: String;
+  sourceId: SourceId;
 };
 
 export type GetEvaluationRequest = {
@@ -11,4 +13,5 @@ export type GetEvaluationRequest = {
   user?: User;
   featureId: string;
   sourceId: SourceId;
+  sdkVersion: String;
 };

--- a/src/objects/request.ts
+++ b/src/objects/request.ts
@@ -2,16 +2,17 @@ import { Event } from './event';
 import { SourceId } from './sourceId';
 import { User } from './user';
 
-export type RegisterEventsRequest = {
-  events: Event[];
-  sdkVersion: String;
+export type BaseRequest = {
   sourceId: SourceId;
+  sdkVersion: string;
 };
 
-export type GetEvaluationRequest = {
+export type RegisterEventsRequest = BaseRequest & {
+  events: Event[];
+};
+
+export type GetEvaluationRequest = BaseRequest & {
   tag: string;
   user?: User;
   featureId: string;
-  sourceId: SourceId;
-  sdkVersion: String;
 };

--- a/src/objects/version.ts
+++ b/src/objects/version.ts
@@ -1,0 +1,1 @@
+export const version: string = require('../../package.json').version;


### PR DESCRIPTION
This PR attached the `sourceID` to the register event request. https://github.com/bucketeer-io/bucketeer/issues/916
This also attached the `sdkVersion` to make consistent with other client SDK

