### PR TITLE
fix: fail to check if error is instance of InvalidStatusError

### DIFF
--- a/src/__tests__/api_failed.ts
+++ b/src/__tests__/api_failed.ts
@@ -1,16 +1,17 @@
-import anyTest, { TestInterface } from 'ava';
+import anyTest, { TestFn } from 'ava';
 import https from 'https';
 import fs from 'fs';
 import { Client } from '../api/client';
 import { User } from '../bootstrap';
 import path from 'path';
+import { InvalidStatusError } from '../api/client';
 
 const apiKey = '';
 
 const port = 9999;
 const host = `localhost:${port}`;
 
-const test = anyTest as TestInterface<{ server: https.Server }>;
+const test = anyTest as TestFn<{ server: https.Server }>;
 const projectRoot = path.join(__dirname, '..', '..');
 const serverKey = path.join(projectRoot, 'src', '__tests__', 'testdata', 'server.key');
 const serverCrt = path.join(projectRoot, 'src', '__tests__', 'testdata', 'server.crt');
@@ -52,9 +53,11 @@ test('getEvaluation: 500', async (t) => {
   try {
     await client.getEvaluation('', user, '');
   } catch (error) {
+    t.true(error instanceof InvalidStatusError);
     err = error.message;
     code = error.code;
   }
+
   t.is(err, 'bucketeer/api: send HTTP request failed: 500');
   t.is(code, 500);
 });
@@ -65,6 +68,7 @@ test('registerEvents: 500', async (t) => {
   try {
     await client.registerEvents([]);
   } catch (error) {
+    t.true(error instanceof InvalidStatusError);
     err = error.message;
   }
   t.is(err, 'bucketeer/api: send HTTP request failed: 500');

--- a/src/__tests__/error_to_metrics_event.ts
+++ b/src/__tests__/error_to_metrics_event.ts
@@ -1,6 +1,5 @@
 import test from 'ava';
 import {
-  createInternalSdkErrorMetricsEvent,
   createTimeoutErrorMetricsEvent,
   createUnknownErrorMetricsEvent,
   createNetworkErrorMetricsEvent,

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -119,5 +119,7 @@ export class InvalidStatusError extends Error {
   constructor(message: string, code: number | undefined) {
     super(message);
     this.code = code;
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, InvalidStatusError.prototype);
   }
 }


### PR DESCRIPTION
When using the library version of the SDK to update the e2e tests. I found the metrics error always be a `UnknowErrorMetricsEvent`

It is caused by the error `InvalidStatusError` is not recognized as it should be. It became the `TypeError`.

**This code below always false**
```ts
error instanceof InvalidStatusError
``` 



The reason is  TypeScript 2.1 had a breaking changes regarding Extending built-ins like Error.

From the [TypeScript breaking changes documentation](https://github.com/microsoft/TypeScript-wiki/blob/81fe7b91664de43c02ea209492ec1cea7f3661d0/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work)