### PR TITLE
refactor: move Bucketeer client logic to a `BKTClientImpl`

### DIFF
--- a/e2e/client.ts
+++ b/e2e/client.ts
@@ -23,19 +23,34 @@ test('Using a random string in the api key setting should not throw exception', 
   // Can not load the evaluation (the correct value should be `false`, but we will received the default value `true`)
   const result = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, true));
   t.true(result);
+
+  const bktClientImpl = bktClient as BKTClientImpl
+  const events = bktClientImpl.eventStore.getAll()
+  t.true(events.some((e) => {
+
+    if (isMetricsEvent(e.event)) {
+      const metrics = e.event as MetricsEvent
+      return metrics.event?.['@type'] === FORBIDDEN_ERROR_METRICS_EVENT_NAME && metrics.event?.apiId === ApiId.GET_EVALUATION
+    }
+    return false;
+  }));
 });
 
 test('altering featureTag should not affect api request', async (t) => {
   const config = {
     host: HOST,
-    token: "TOKEN_RANDOM",
+    token: TOKEN,
     tag: FEATURE_TAG,
     logger: new DefaultLogger("error")
   }
   const bktClient = initialize(config);
   const user = { id: TARGETED_USER_ID, data: {} }
-  const result = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, true));
+  const result = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, false));
   t.true(result);
+  config.tag = "RANDOME"
+
+  const resultAfterAlterAPIKey = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, false));
+  t.true(resultAfterAlterAPIKey);
 });
 
 test('Altering the api key should not affect api request', async (t) => {
@@ -71,7 +86,6 @@ test('Using a random string in the featureTag setting should affect api request'
   const bktClientImpl = bktClient as BKTClientImpl
   const events = bktClientImpl.eventStore.getAll()
   t.true(events.some((e) => {
-
     if (isMetricsEvent(e.event)) {
       const metrics = e.event as MetricsEvent
       return metrics.event?.['@type'] === NOT_FOUND_ERROR_METRICS_EVENT_NAME && metrics.event?.apiId === ApiId.GET_EVALUATION

--- a/e2e/client.ts
+++ b/e2e/client.ts
@@ -2,14 +2,60 @@ import test from 'ava'
 import { initialize, DefaultLogger } from '../lib';
 import { HOST, TOKEN, FEATURE_TAG, TARGETED_USER_ID, FEATURE_ID_BOOLEAN } from './constants/constants';
 
+//Note: This is different compared to other SDK clients.
 test('Using a random string in the api key setting should not throw exception', async (t) => {
-    const bktClient = initialize({
-        host: HOST,
-        token: "TOKEN_RANDOM",
-        tag: FEATURE_TAG,
-        logger: new DefaultLogger("error")
-      });
-    const user = { id: TARGETED_USER_ID, data: {} }
-    const result = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, true));
-    t.true(result);
+  const bktClient = initialize({
+    host: HOST,
+    token: "TOKEN_RANDOM",
+    tag: FEATURE_TAG,
+    logger: new DefaultLogger("error")
   });
+  const user = { id: TARGETED_USER_ID, data: {} }
+  // Can not load the evaluation (the correct value should be `false`, but we will received the default value `true`)
+  const result = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, true));
+  t.true(result);
+});
+
+test('altering featureTag should not affect api request', async (t) => {
+  const config = {
+    host: HOST,
+    token: "TOKEN_RANDOM",
+    tag: FEATURE_TAG,
+    logger: new DefaultLogger("error")
+  }
+  const bktClient = initialize(config);
+  const user = { id: TARGETED_USER_ID, data: {} }
+  const result = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, true));
+  t.true(result);
+});
+
+test('Altering the api key should not affect api request', async (t) => {
+  const config = {
+    host: HOST,
+    token: TOKEN,
+    tag: FEATURE_TAG,
+    logger: new DefaultLogger("error")
+  }
+  const bktClient = initialize(config);
+  const user = { id: TARGETED_USER_ID, data: {} }
+  const result = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, false));
+  t.true(result);
+  config.token = "RANDOME"
+
+  const resultAfterAlterAPIKey = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, false));
+  t.true(resultAfterAlterAPIKey);
+});
+
+//Note: This is different compared to other SDK clients.
+test('Using a random string in the featureTag setting should affect api request', async (t) => {
+  const bktClient = initialize({
+    host: HOST,
+    token: TOKEN,
+    tag: "RANDOM",
+    logger: new DefaultLogger("error")
+  });
+  const user = { id: TARGETED_USER_ID, data: {} }
+  const result = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, true));
+  // Can not load the evaluation (the correct value should be `false`, but we will received the default value `true`)
+  t.true(result);
+});

--- a/e2e/client.ts
+++ b/e2e/client.ts
@@ -11,7 +11,7 @@ const NOT_FOUND_ERROR_METRICS_EVENT_NAME =
 const UNKNOWN_ERROR_METRICS_EVENT_NAME =
   'type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent';
 
-//Note: Thre is different compared to other SDK clients.
+//Note: There is a different compared to other SDK clients.
 test('Using a random string in the api key setting should not throw exception', async (t) => {
   const bktClient = initialize({
     host: HOST,
@@ -71,7 +71,7 @@ test('Altering the api key should not affect api request', async (t) => {
   t.true(resultAfterAlterAPIKey);
 });
 
-//Note: Thre is different compared to other SDK clients.
+//Note: There is a different compared to other SDK clients.
 test('Using a random string in the featureTag setting should affect api request', async (t) => {
   const bktClient = initialize({
     host: HOST,

--- a/e2e/client.ts
+++ b/e2e/client.ts
@@ -35,6 +35,8 @@ test('Using a random string in the api key setting should not throw exception', 
     }
     return false;
   }));
+
+  bktClient.destroy()
 });
 
 test('altering featureTag should not affect api request', async (t) => {
@@ -52,6 +54,8 @@ test('altering featureTag should not affect api request', async (t) => {
 
   const resultAfterAlterAPIKey = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, false));
   t.true(resultAfterAlterAPIKey);
+
+  bktClient.destroy()
 });
 
 test('Altering the api key should not affect api request', async (t) => {
@@ -69,6 +73,8 @@ test('Altering the api key should not affect api request', async (t) => {
 
   const resultAfterAlterAPIKey = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, false));
   t.true(resultAfterAlterAPIKey);
+
+  bktClient.destroy()
 });
 
 //Note: There is a different compared to other SDK clients.
@@ -94,4 +100,6 @@ test('Using a random string in the featureTag setting should affect api request'
     }
     return false;
   }));
+
+  bktClient.destroy()
 });

--- a/e2e/client.ts
+++ b/e2e/client.ts
@@ -74,7 +74,7 @@ test('Using a random string in the featureTag setting should affect api request'
 
     if (isMetricsEvent(e.event)) {
       const metrics = e.event as MetricsEvent
-      return metrics.event?.['@type'] === UNKNOWN_ERROR_METRICS_EVENT_NAME && metrics.event?.apiId === ApiId.GET_EVALUATION
+      return metrics.event?.['@type'] === NOT_FOUND_ERROR_METRICS_EVENT_NAME && metrics.event?.apiId === ApiId.GET_EVALUATION
     }
     return false;
   }));

--- a/e2e/client.ts
+++ b/e2e/client.ts
@@ -11,7 +11,7 @@ const NOT_FOUND_ERROR_METRICS_EVENT_NAME =
 const UNKNOWN_ERROR_METRICS_EVENT_NAME =
   'type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent';
 
-//Note: This is different compared to other SDK clients.
+//Note: Thre is different compared to other SDK clients.
 test('Using a random string in the api key setting should not throw exception', async (t) => {
   const bktClient = initialize({
     host: HOST,
@@ -20,7 +20,8 @@ test('Using a random string in the api key setting should not throw exception', 
     logger: new DefaultLogger("error")
   });
   const user = { id: TARGETED_USER_ID, data: {} }
-  // Can not load the evaluation (the correct value should be `false`, but we will received the default value `true`)
+  // The client can not load the evaluation, we will received the default value `true`
+  // Other SDK clients e2e test will expect the value is `false`
   const result = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, true));
   t.true(result);
 
@@ -70,7 +71,7 @@ test('Altering the api key should not affect api request', async (t) => {
   t.true(resultAfterAlterAPIKey);
 });
 
-//Note: This is different compared to other SDK clients.
+//Note: Thre is different compared to other SDK clients.
 test('Using a random string in the featureTag setting should affect api request', async (t) => {
   const bktClient = initialize({
     host: HOST,
@@ -80,7 +81,8 @@ test('Using a random string in the featureTag setting should affect api request'
   });
   const user = { id: TARGETED_USER_ID, data: {} }
   const result = await t.notThrowsAsync(bktClient.getBoolVariation(user, FEATURE_ID_BOOLEAN, true));
-  // Can not load the evaluation (the correct value should be `false`, but we will received the default value `true`)
+  // The client can not load the evaluation, we will received the default value `true`
+  // Other SDK clients e2e test will expect the value is `false`
   t.true(result);
 
   const bktClientImpl = bktClient as BKTClientImpl

--- a/e2e/evaluations_defaut_strategy.ts
+++ b/e2e/evaluations_defaut_strategy.ts
@@ -35,7 +35,7 @@ test('numberVariation', async (t) => {
 
 test('jsonVariation', async (t) => {
   const { bktClient, defaultUser } = t.context;
-  t.deepEqual(await bktClient.getJsonVariation(defaultUser, FEATURE_ID_JSON, {}),  {"str":"str1", "int": "int1"});
+  t.deepEqual(await bktClient.getJsonVariation(defaultUser, FEATURE_ID_JSON, {}), { "str": "str1", "int": "int1" });
 });
 
 test.afterEach(async (t) => {

--- a/e2e/evaluations_targeting_strategy.ts
+++ b/e2e/evaluations_targeting_strategy.ts
@@ -3,7 +3,7 @@ import { Bucketeer, DefaultLogger, User, initialize } from '../lib';
 import { HOST, TOKEN, FEATURE_TAG, TARGETED_USER_ID, FEATURE_ID_BOOLEAN, FEATURE_ID_STRING, FEATURE_ID_INT, FEATURE_ID_JSON, FEATURE_ID_FLOAT } from './constants/constants';
 
 
-const test = anyTest as TestFn<{ bktClient: Bucketeer; targetedUser: User}>;
+const test = anyTest as TestFn<{ bktClient: Bucketeer; targetedUser: User }>;
 
 test.beforeEach((t) => {
   t.context = {
@@ -18,24 +18,24 @@ test.beforeEach((t) => {
 });
 
 test('boolVariation', async (t) => {
-  const { bktClient, targetedUser} = t.context;
+  const { bktClient, targetedUser } = t.context;
   t.is(await bktClient.getBoolVariation(targetedUser, FEATURE_ID_BOOLEAN, true), false);
 });
 
 test('stringVariation', async (t) => {
-  const { bktClient, targetedUser} = t.context;
+  const { bktClient, targetedUser } = t.context;
   t.is(await bktClient.getStringVariation(targetedUser, FEATURE_ID_STRING, ''), 'value-2');
 });
 
 test('numberVariation', async (t) => {
-  const { bktClient, targetedUser} = t.context;
+  const { bktClient, targetedUser } = t.context;
   t.is(await bktClient.getNumberVariation(targetedUser, FEATURE_ID_INT, 0), 20);
   t.is(await bktClient.getNumberVariation(targetedUser, FEATURE_ID_FLOAT, 0.0), 3.1);
 });
 
 test('jsonVariation', async (t) => {
   const { bktClient, targetedUser } = t.context;
-  t.deepEqual(await bktClient.getJsonVariation(targetedUser, FEATURE_ID_JSON, {}),  {"str":"str2", "int": "int2"});
+  t.deepEqual(await bktClient.getJsonVariation(targetedUser, FEATURE_ID_JSON, {}), { "str": "str2", "int": "int2" });
 });
 
 test.afterEach(async (t) => {

--- a/e2e/events.ts
+++ b/e2e/events.ts
@@ -3,6 +3,8 @@ import { Bucketeer, DefaultLogger, User, initialize } from '../lib';
 import { HOST, TOKEN, FEATURE_TAG, TARGETED_USER_ID, FEATURE_ID_BOOLEAN, FEATURE_ID_STRING, FEATURE_ID_INT, FEATURE_ID_JSON, FEATURE_ID_FLOAT, GOAL_ID, GOAL_VALUE } from './constants/constants';
 import { BKTClientImpl } from '../lib';
 import { isGoalEvent } from '../lib/objects/goalEvent';
+import { isMetricsEvent } from '../lib/objects/metricsEvent';
+import { isEvaluationEvent } from '../lib/objects/evaluationEvent';
 
 const test = anyTest as TestFn<{ bktClient: Bucketeer; targetedUser: User }>;
 
@@ -25,7 +27,7 @@ test('goal event', async (t) => {
   bktClient.track(targetedUser, GOAL_ID, GOAL_VALUE)
   const bktClientImpl = bktClient as BKTClientImpl
   const events = bktClientImpl.eventStore.getAll()
-  // EvaluationEvent, Metrics Event - Latency, Metrics Event - Metrics Size, Goal Event
+  // (EvaluationEvent, Metrics Event - Latency, Metrics Event - Metrics Size, Goal Event)
   t.is(events.length, 4);
   t.true(events.some((e: { event: any; }) => (isGoalEvent(e.event))))
 });
@@ -39,8 +41,8 @@ test('default evaluation event', async (t) => {
   t.is(await bktClient.getStringVariation(targetedUser, FEATURE_ID_STRING, ''), 'value-2');
   const bktClientImpl = bktClient as BKTClientImpl
   const events = bktClientImpl.eventStore.getAll()
-  // (EvaluationEvent, Metrics Event - Latency, Metrics Event - Metrics Size, Goal Event) x 5
+  // (EvaluationEvent, Metrics Event - Latency, Metrics Event - Metrics Size) x 5
   t.is(events.length, 15);
-  t.true(events.some((e: { event: any; }) => (isGoalEvent(e.event))));
-  t.true(events.some((e: { event: any; }) => (isGoalEvent(e.event))));
+  t.true(events.some((e) => (isEvaluationEvent(e.event))));
+  t.true(events.some((e) => (isMetricsEvent(e.event))));
 });

--- a/e2e/events.ts
+++ b/e2e/events.ts
@@ -1,0 +1,31 @@
+import anyTest, { TestFn } from 'ava';
+import { Bucketeer, DefaultLogger, User, initialize } from '../lib';
+import { HOST, TOKEN, FEATURE_TAG, TARGETED_USER_ID, FEATURE_ID_BOOLEAN, FEATURE_ID_STRING, FEATURE_ID_INT, FEATURE_ID_JSON, FEATURE_ID_FLOAT, GOAL_ID, GOAL_VALUE } from './constants/constants';
+import { BKTClientImpl } from '../lib';
+import { isGoalEvent } from '../lib/objects/goalEvent';
+
+const test = anyTest as TestFn<{ bktClient: Bucketeer; targetedUser: User }>;
+
+test.beforeEach((t) => {
+  t.context = {
+    bktClient: initialize({
+      host: HOST,
+      token: TOKEN,
+      tag: FEATURE_TAG,
+      logger: new DefaultLogger("error")
+    }),
+    targetedUser: { id: TARGETED_USER_ID, data: {} }
+  };
+});
+
+
+test('goal event', async (t) => {
+    const { bktClient, targetedUser } = t.context;
+    t.is(await bktClient.getBoolVariation(targetedUser, FEATURE_ID_BOOLEAN, true), false);
+    bktClient.track(targetedUser, GOAL_ID, GOAL_VALUE)
+    const bktClientImpl = bktClient as BKTClientImpl
+    const events = bktClientImpl.eventStore.getAll()
+  // EvaluationEvent, Metrics Event - Latency, Metrics Event - Metrics Size, Goal Event
+    t.is(events.length, 4);
+    t.true(events.some((e) => (isGoalEvent(e.event))))
+  });

--- a/e2e/events.ts
+++ b/e2e/events.ts
@@ -46,3 +46,9 @@ test('default evaluation event', async (t) => {
   t.true(events.some((e) => (isEvaluationEvent(e.event))));
   t.true(events.some((e) => (isMetricsEvent(e.event))));
 });
+
+test.afterEach(async (t) => {
+  const { bktClient } = t.context;
+  bktClient.destroy();
+});
+

--- a/e2e/events.ts
+++ b/e2e/events.ts
@@ -20,12 +20,27 @@ test.beforeEach((t) => {
 
 
 test('goal event', async (t) => {
-    const { bktClient, targetedUser } = t.context;
-    t.is(await bktClient.getBoolVariation(targetedUser, FEATURE_ID_BOOLEAN, true), false);
-    bktClient.track(targetedUser, GOAL_ID, GOAL_VALUE)
-    const bktClientImpl = bktClient as BKTClientImpl
-    const events = bktClientImpl.eventStore.getAll()
+  const { bktClient, targetedUser } = t.context;
+  t.is(await bktClient.getBoolVariation(targetedUser, FEATURE_ID_BOOLEAN, true), false);
+  bktClient.track(targetedUser, GOAL_ID, GOAL_VALUE)
+  const bktClientImpl = bktClient as BKTClientImpl
+  const events = bktClientImpl.eventStore.getAll()
   // EvaluationEvent, Metrics Event - Latency, Metrics Event - Metrics Size, Goal Event
-    t.is(events.length, 4);
-    t.true(events.some((e) => (isGoalEvent(e.event))))
-  });
+  t.is(events.length, 4);
+  t.true(events.some((e: { event: any; }) => (isGoalEvent(e.event))))
+});
+
+test('default evaluation event', async (t) => {
+  const { bktClient, targetedUser } = t.context;
+  t.is(await bktClient.getBoolVariation(targetedUser, FEATURE_ID_BOOLEAN, true), false);
+  t.deepEqual(await bktClient.getJsonVariation(targetedUser, FEATURE_ID_JSON, {}), { "str": "str2", "int": "int2" });
+  t.is(await bktClient.getNumberVariation(targetedUser, FEATURE_ID_INT, 0), 20);
+  t.is(await bktClient.getNumberVariation(targetedUser, FEATURE_ID_FLOAT, 0.0), 3.1);
+  t.is(await bktClient.getStringVariation(targetedUser, FEATURE_ID_STRING, ''), 'value-2');
+  const bktClientImpl = bktClient as BKTClientImpl
+  const events = bktClientImpl.eventStore.getAll()
+  // (EvaluationEvent, Metrics Event - Latency, Metrics Event - Metrics Size, Goal Event) x 5
+  t.is(events.length, 15);
+  t.true(events.some((e: { event: any; }) => (isGoalEvent(e.event))));
+  t.true(events.some((e: { event: any; }) => (isGoalEvent(e.event))));
+});

--- a/src/__tests__/api_failed.ts
+++ b/src/__tests__/api_failed.ts
@@ -1,7 +1,7 @@
-import anyTest, { TestInterface } from 'ava';
+import anyTest, { TestFn } from 'ava';
 import https from 'https';
 import fs from 'fs';
-import { Client } from '../api/client';
+import { APIClient } from '../api/client';
 import { User } from '../bootstrap';
 import path from 'path';
 
@@ -10,7 +10,7 @@ const apiKey = '';
 const port = 9999;
 const host = `localhost:${port}`;
 
-const test = anyTest as TestInterface<{ server: https.Server }>;
+const test = anyTest as TestFn<{ server: https.Server }>;
 const projectRoot = path.join(__dirname, '..', '..');
 const serverKey = path.join(projectRoot, 'src', '__tests__', 'testdata', 'server.key');
 const serverCrt = path.join(projectRoot, 'src', '__tests__', 'testdata', 'server.crt');
@@ -40,7 +40,7 @@ test.after.always((t) => {
 });
 
 test('getEvaluation: 500', async (t) => {
-  const client = new Client(host, apiKey);
+  const client = new APIClient(host, apiKey);
   const user: User = {
     id: '',
     data: {
@@ -60,7 +60,7 @@ test('getEvaluation: 500', async (t) => {
 });
 
 test('registerEvents: 500', async (t) => {
-  const client = new Client(host, apiKey);
+  const client = new APIClient(host, apiKey);
   let err = '';
   try {
     await client.registerEvents([]);

--- a/src/__tests__/api_success.ts
+++ b/src/__tests__/api_success.ts
@@ -1,7 +1,7 @@
 import anyTest, { TestFn } from 'ava';
 import https from 'https';
 import fs from 'fs';
-import { Client } from '../api/client';
+import { APIClient } from '../api/client';
 import { User } from '../bootstrap';
 import path from 'path';
 import { v4 } from 'uuid';
@@ -89,7 +89,7 @@ test.after.always((t) => {
 });
 
 test('getEvaluation: success', async (t) => {
-  const client = new Client(host, apiKey);
+  const client = new APIClient(host, apiKey);
   const user: User = {
     id: '',
     data: {
@@ -101,7 +101,7 @@ test('getEvaluation: success', async (t) => {
 });
 
 test('registerEvents', async (t) => {
-  const client = new Client(host, apiKey);
+  const client = new APIClient(host, apiKey);
   const [res] = await client.registerEvents([]);
   t.is(res.errors.key.message, dummpyRegisterEvtsResponse.errors.key.message);
   t.is(res.errors.key.retriable, dummpyRegisterEvtsResponse.errors.key.retriable);

--- a/src/__tests__/event.ts
+++ b/src/__tests__/event.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import { Evaluation } from '../objects/evaluation';
 import { SourceId } from '../objects/sourceId';
 import { ReasonType, Reason } from '../objects/reason';
-import { GoalEvent, createGoalEvent } from '../objects/goalEvent';
+import { GoalEvent, createGoalEvent, isGoalEvent } from '../objects/goalEvent';
 import { User } from '../objects/user';
 import { createTimestamp } from '../utils/time';
 import {
@@ -107,7 +107,36 @@ test('createGoalEvent', (t) => {
     '@type': GOAL_EVENT_NAME,
   };
   const actual = createGoalEvent(goalEvent.tag, goalEvent.goalId, user, goalEvent.value);
+  t.true(isGoalEvent(goalEvent));
+  t.true(isGoalEvent(actual.event));
   t.deepEqual(actual.event, goalEvent);
+});
+
+test('isGoalEvent', (t) => {
+  const evaluationEvent: EvaluationEvent = {
+    tag,
+    user,
+    timestamp: createTimestamp(),
+    featureId,
+    featureVersion,
+    userId,
+    variationId,
+    sourceId,
+    reason,
+    '@type': EVALUATION_EVENT_NAME,
+    sdkVersion,
+    metadata,
+  };
+  const getEvaluationLatencyMetricsEvent: LatencyMetricsEvent = {
+    apiId,
+    latencySecond: second,
+    labels: {
+      tag,
+    },
+    '@type': LATENCY_METRICS_EVENT_NAME,
+  };
+  t.false(isGoalEvent(evaluationEvent));
+  t.false(isGoalEvent(getEvaluationLatencyMetricsEvent));
 });
 
 test('createEvaluationEvent', (t) => {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -10,7 +10,7 @@ const scheme = 'https://';
 const evaluationAPI = '/get_evaluation';
 const eventsAPI = '/register_events';
 
-export class Client {
+export class APIClient {
   private readonly host: string;
   private readonly apiKey: string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,35 +2,19 @@ import { User } from './objects/user';
 import { EventStore } from './stores/EventStore';
 import { createSchedule, removeSchedule } from './schedule';
 import { GIT_REVISION } from './shared';
-import { Client as APIClient, InvalidStatusError } from './api/client';
+import { APIClient } from './api/client';
 import { Config, defaultConfig } from './config';
 import { createDefaultEvaluationEvent, createEvaluationEvent } from './objects/evaluationEvent';
 import { createGoalEvent } from './objects/goalEvent';
 import {
   createLatencyMetricsEvent,
   createSizeMetricsEvent,
-  createInternalSdkErrorMetricsEvent,
-  createTimeoutErrorMetricsEvent,
-  createNetworkErrorMetricsEvent,
-  createUnknownErrorMetricsEvent,
   toErrorMetricsEvent,
 } from './objects/metricsEvent';
 import { Evaluation } from './objects/evaluation';
 import { Event } from './objects/event';
 import { GetEvaluationResponse } from './objects/response';
 import { ApiId, NodeApiIds } from './objects/apiId';
-import {
-  createBadRequestErrorMetricsEvent,
-  createClientClosedRequestErrorMetricsEvent,
-  createForbiddenErrorMetricsEvent,
-  createInternalServerErrorMetricsEvent,
-  createNotFoundErrorMetricsEvent,
-  createPayloadTooLargeErrorMetricsEvent,
-  createRedirectRequestErrorMetricsEvent,
-  createServiceUnavailableErrorMetricsEvent,
-  createUnauthorizedErrorMetricsEvent,
-} from './objects/status';
-import { Logger } from './logger';
 
 export interface BuildInfo {
   readonly GIT_REVISION: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   createServiceUnavailableErrorMetricsEvent,
   createUnauthorizedErrorMetricsEvent,
 } from './objects/status';
+import { Logger } from './logger';
 
 export interface BuildInfo {
   readonly GIT_REVISION: string;
@@ -106,243 +107,256 @@ const COUNT_PER_REGISTER_EVENT = 100;
  * @returns Bucketeer SDK instance.
  */
 export function initialize(config: Config): Bucketeer {
-  const { host, token, tag, pollingIntervalForRegisterEvents, logger } = {
-    ...defaultConfig,
-    ...config,
-  };
+  return new BKTClientImpl(config);
+}
 
-  const client = new Client(host, token);
+export class BKTClientImpl implements Bucketeer {
+  client: Client;
+  eventStore: EventStore;
+  config: Config;
+  registerEventsScheduleID: NodeJS.Timeout;
 
-  const eventStore = new EventStore();
+  constructor(config: Config) {
+    this.config = {
+      ...defaultConfig,
+      ...config,
+    };
 
-  function registerEvents(): void {
-    if (eventStore.size() >= COUNT_PER_REGISTER_EVENT) {
-      callRegisterEvents(eventStore.takeout(COUNT_PER_REGISTER_EVENT));
+    this.client = new Client(this.config.host, this.config.token);
+    this.eventStore = new EventStore();
+    this.registerEventsScheduleID = createSchedule(() => {
+      if (this.eventStore.size() > 0) {
+        this.callRegisterEvents(this.eventStore.takeout(this.eventStore.size()));
+      }
+    }, this.config.pollingIntervalForRegisterEvents!);
+  }
+
+  registerEvents(): void {
+    if (this.eventStore.size() >= COUNT_PER_REGISTER_EVENT) {
+      this.callRegisterEvents(this.eventStore.takeout(COUNT_PER_REGISTER_EVENT));
     }
   }
 
-  function registerAllEvents(): void {
-    if (eventStore.size() > 0) {
-      callRegisterEvents(eventStore.getAll());
+  registerAllEvents(): void {
+    if (this.eventStore.size() > 0) {
+      this.callRegisterEvents(this.eventStore.getAll());
     }
   }
 
-  const registerEventsScheduleID = createSchedule(() => {
-    if (eventStore.size() > 0) {
-      callRegisterEvents(eventStore.takeout(eventStore.size()));
-    }
-  }, pollingIntervalForRegisterEvents);
-
-  function callRegisterEvents(events: Array<Event>): void {
-    client.registerEvents(events).catch((e) => {
-      saveErrorMetricsEvent(e, ApiId.REGISTER_EVENTS);
-      logger.warn('register events failed', e);
+  callRegisterEvents(events: Array<Event>): void {
+    this.client.registerEvents(events).catch((e) => {
+      this.saveErrorMetricsEvent(e, ApiId.REGISTER_EVENTS);
+      this.config.logger?.warn('register events failed', e);
     });
   }
 
-  function saveDefaultEvaluationEvent(user: User, featureId: string) {
-    eventStore.add(createDefaultEvaluationEvent(tag, user, featureId));
-    registerEvents();
+  saveDefaultEvaluationEvent(user: User, featureId: string) {
+    this.eventStore.add(createDefaultEvaluationEvent(this.config.tag, user, featureId));
+    this.registerEvents();
   }
 
-  function saveEvaluationEvent(user: User, evaluation: Evaluation) {
-    eventStore.add(createEvaluationEvent(tag, user, evaluation));
-    registerEvents();
+  saveEvaluationEvent(user: User, evaluation: Evaluation) {
+    this.eventStore.add(createEvaluationEvent(this.config.tag, user, evaluation));
+    this.registerEvents();
   }
 
-  function saveGoalEvent(user: User, goalId: string, value?: number) {
-    eventStore.add(createGoalEvent(tag, goalId, user, value ? value : 0));
-    registerEvents();
+  saveGoalEvent(user: User, goalId: string, value?: number) {
+    this.eventStore.add(createGoalEvent(this.config.tag, goalId, user, value ? value : 0));
+    this.registerEvents();
   }
 
-  function saveEvaluationMetricsEvent(tag: string, second: number, size: number) {
-    saveLatencyMetricsEvent(tag, second, ApiId.GET_EVALUATION);
-    saveSizeMetricsEvent(tag, size, ApiId.GET_EVALUATION);
+  saveEvaluationMetricsEvent(tag: string, second: number, size: number) {
+    this.saveLatencyMetricsEvent(tag, second, ApiId.GET_EVALUATION);
+    this.saveSizeMetricsEvent(tag, size, ApiId.GET_EVALUATION);
   }
 
-  function saveLatencyMetricsEvent(tag: string, second: number, apiId: NodeApiIds) {
-    eventStore.add(createLatencyMetricsEvent(tag, second, apiId));
-    registerEvents();
+  saveLatencyMetricsEvent(tag: string, second: number, apiId: NodeApiIds) {
+    this.eventStore.add(createLatencyMetricsEvent(tag, second, apiId));
+    this.registerEvents();
   }
 
-  function saveSizeMetricsEvent(tag: string, size: number, apiId: NodeApiIds) {
-    eventStore.add(createSizeMetricsEvent(tag, size, apiId));
-    registerEvents();
+  saveSizeMetricsEvent(tag: string, size: number, apiId: NodeApiIds) {
+    this.eventStore.add(createSizeMetricsEvent(tag, size, apiId));
+    this.registerEvents();
   }
 
-  function saveInternalSdkErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createInternalSdkErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveInternalSdkErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createInternalSdkErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function saveTimeoutErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createTimeoutErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveTimeoutErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createTimeoutErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function saveNetworkErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createNetworkErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveNetworkErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createNetworkErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function saveBadRequestErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createBadRequestErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveBadRequestErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createBadRequestErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function saveUnauthorizedErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createUnauthorizedErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveUnauthorizedErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createUnauthorizedErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function saveForbiddenErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createForbiddenErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveForbiddenErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createForbiddenErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function saveNotFoundErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createNotFoundErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveNotFoundErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createNotFoundErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function saveClientClosedRequestErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createClientClosedRequestErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveClientClosedRequestErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createClientClosedRequestErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function saveInternalServerErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createInternalServerErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveInternalServerErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createInternalServerErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function saveServiceUnavailableErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createServiceUnavailableErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveServiceUnavailableErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createServiceUnavailableErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function saveUnknownErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
-    eventStore.add(createUnknownErrorMetricsEvent(tag, apiId));
-    registerEvents();
+  saveUnknownErrorMetricsEvent(tag: string, apiId: NodeApiIds) {
+    this.eventStore.add(createUnknownErrorMetricsEvent(tag, apiId));
+    this.registerEvents();
   }
 
-  function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  isNodeError(error: unknown): error is NodeJS.ErrnoException {
     return typeUtils.isNativeError(error);
   }
 
-  function saveErrorMetricsEvent(e: any, apiId: NodeApiIds) {
+  saveErrorMetricsEvent(e: any, apiId: NodeApiIds) {
     if (e instanceof InvalidStatusError) {
       switch (e.code) {
         case 400:
-          saveBadRequestErrorMetricsEvent(tag, apiId);
+          this.saveBadRequestErrorMetricsEvent(this.config.tag, apiId);
           break;
         case 401:
-          saveUnauthorizedErrorMetricsEvent(tag, apiId);
+          this.saveUnauthorizedErrorMetricsEvent(this.config.tag, apiId);
           break;
         case 403:
-          saveForbiddenErrorMetricsEvent(tag, apiId);
+          this.saveForbiddenErrorMetricsEvent(this.config.tag, apiId);
           break;
         case 404:
-          saveNotFoundErrorMetricsEvent(tag, apiId);
+          this.saveNotFoundErrorMetricsEvent(this.config.tag, apiId);
           break;
         case 499:
-          saveClientClosedRequestErrorMetricsEvent(tag, apiId);
+          this.saveClientClosedRequestErrorMetricsEvent(this.config.tag, apiId);
           break;
         case 500:
-          saveInternalServerErrorMetricsEvent(tag, apiId);
+          this.saveInternalServerErrorMetricsEvent(this.config.tag, apiId);
           break;
         case 503:
-          saveServiceUnavailableErrorMetricsEvent(tag, apiId);
+          this.saveServiceUnavailableErrorMetricsEvent(this.config.tag, apiId);
           break;
         case 504:
-          saveTimeoutErrorMetricsEvent(tag, apiId);
+          this.saveTimeoutErrorMetricsEvent(this.config.tag, apiId);
           break;
         default:
-          saveUnknownErrorMetricsEvent(tag, apiId);
+          this.saveUnknownErrorMetricsEvent(this.config.tag, apiId);
           break;
       }
       return;
     }
-    if (isNodeError(e)) {
+    if (this.isNodeError(e)) {
       switch (e.code) {
         case 'ECONNRESET':
-          saveTimeoutErrorMetricsEvent(tag, apiId);
+          this.saveTimeoutErrorMetricsEvent(this.config.tag, apiId);
           break;
         case 'EHOSTUNREACH':
         case 'ECONNREFUSED':
-          saveNetworkErrorMetricsEvent(tag, apiId);
+          this.saveNetworkErrorMetricsEvent(this.config.tag, apiId);
           break;
         default:
-          saveInternalSdkErrorMetricsEvent(tag, apiId);
+          this.saveInternalSdkErrorMetricsEvent(this.config.tag, apiId);
           break;
       }
       return;
     }
   }
 
-  return {
-    async getStringVariation(user: User, featureId: string, defaultValue: string): Promise<string> {
-      const startTime: number = Date.now();
-      let res: GetEvaluationResponse;
-      let size: number;
-      try {
-        [res, size] = await client.getEvaluation(tag, user, featureId);
-      } catch (error) {
-        saveErrorMetricsEvent(error, ApiId.GET_EVALUATION);
-        saveDefaultEvaluationEvent(user, featureId);
+  async getStringVariation(user: User, featureId: string, defaultValue: string): Promise<string> {
+    const startTime: number = Date.now();
+    let res: GetEvaluationResponse;
+    let size: number;
+    try {
+      [res, size] = await this.client.getEvaluation(this.config.tag, user, featureId);
+    } catch (error) {
+      this.saveErrorMetricsEvent(error, ApiId.GET_EVALUATION);
+      this.saveDefaultEvaluationEvent(user, featureId);
+      return defaultValue;
+    }
+    const evaluation = res?.evaluation;
+    if (evaluation == null) {
+      this.saveDefaultEvaluationEvent(user, featureId);
+      return defaultValue;
+    }
+    const second = (Date.now() - startTime) / 1000;
+    this.saveEvaluationEvent(user, evaluation);
+    this.saveEvaluationMetricsEvent(this.config.tag, second, size);
+    return evaluation.variationValue;
+  }
+
+  async getBoolVariation(user: User, featureId: string, defaultValue: boolean): Promise<boolean> {
+    const valueStr = await this.getStringVariation(user, featureId, '');
+    switch (valueStr.toLowerCase()) {
+      case 'true':
+        return true;
+      case 'false':
+        return false;
+      default:
         return defaultValue;
-      }
-      const evaluation = res?.evaluation;
-      if (evaluation == null) {
-        saveDefaultEvaluationEvent(user, featureId);
-        return defaultValue;
-      }
-      const second = (Date.now() - startTime) / 1000;
-      saveEvaluationEvent(user, evaluation);
-      saveEvaluationMetricsEvent(tag, second, size);
-      return evaluation.variationValue;
-    },
-    async getBoolVariation(user: User, featureId: string, defaultValue: boolean): Promise<boolean> {
-      const valueStr = await this.getStringVariation(user, featureId, '');
-      switch (valueStr.toLowerCase()) {
-        case 'true':
-          return true;
-        case 'false':
-          return false;
-        default:
-          return defaultValue;
-      }
-    },
-    async getNumberVariation(user: User, featureId: string, defaultValue: number): Promise<number> {
-      const valueStr = await this.getStringVariation(user, featureId, '');
-      const value = parseFloat(valueStr);
-      if (isNaN(value)) {
-        logger.debug('getNumberVariation failed to parseFloat');
-        return defaultValue;
-      }
-      return value;
-    },
-    async getJsonVariation(user: User, featureId: string, defaultValue: object): Promise<object> {
-      const valueStr = await this.getStringVariation(user, featureId, '');
-      try {
-        return JSON.parse(valueStr);
-      } catch (e) {
-        logger.debug('getJsonVariation failed to parse', e);
-        return defaultValue;
-      }
-    },
-    track(user: User, goalId: string, value?: number): void {
-      logger.debug('track is called', goalId, value);
-      saveGoalEvent(user, goalId, value);
-    },
-    async destroy(): Promise<void> {
-      await registerAllEvents();
-      removeSchedule(registerEventsScheduleID);
-      logger.info('destroy finished', registerEventsScheduleID);
-    },
-    getBuildInfo(): BuildInfo {
-      return {
-        GIT_REVISION,
-      };
-    },
-  };
+    }
+  }
+
+  async getNumberVariation(user: User, featureId: string, defaultValue: number): Promise<number> {
+    const valueStr = await this.getStringVariation(user, featureId, '');
+    const value = parseFloat(valueStr);
+    if (isNaN(value)) {
+      this.config.logger?.debug('getNumberVariation failed to parseFloat');
+      return defaultValue;
+    }
+    return value;
+  }
+
+  async getJsonVariation(user: User, featureId: string, defaultValue: object): Promise<object> {
+    const valueStr = await this.getStringVariation(user, featureId, '');
+    try {
+      return JSON.parse(valueStr);
+    } catch (e) {
+      this.config.logger?.debug('getJsonVariation failed to parse', e);
+      return defaultValue;
+    }
+  }
+
+  track(user: User, goalId: string, value?: number): void {
+    this.config.logger?.debug('track is called', goalId, value);
+    this.saveGoalEvent(user, goalId, value);
+  }
+
+  async destroy(): Promise<void> {
+    await this.registerAllEvents();
+    removeSchedule(this.registerEventsScheduleID);
+    this.config.logger?.info('destroy finished', this.registerEventsScheduleID);
+  }
+
+  getBuildInfo(): BuildInfo {
+    return {
+      GIT_REVISION,
+    };
+  }
 }

--- a/src/objects/evaluationEvent.ts
+++ b/src/objects/evaluationEvent.ts
@@ -60,3 +60,38 @@ export function createDefaultEvaluationEvent(tag: string, user: User, featureId:
   };
   return createEvent(evaluationEvent);
 }
+
+export function isEvaluationEvent(obj: any): obj is EvaluationEvent {
+  const isObject = typeof obj === 'object' && obj !== null;
+  const hasTimestamp = typeof obj.timestamp === 'number';
+  const hasFeatureId = typeof obj.featureId === 'string';
+  const hasFeatureVersion = typeof obj.featureVersion === 'number';
+  const hasUserId = typeof obj.userId === 'string';
+  const hasVariationId = typeof obj.variationId === 'string';
+  const hasUser = obj.user === undefined || typeof obj.user === 'object';
+  const hasReason = obj.reason === undefined || typeof obj.reason === 'object';
+  const hasTag = typeof obj.tag === 'string';
+  const hasSourceId = obj.sourceId === SourceId.NODE_SERVER;
+  const hasSdkVersion = typeof obj.sdkVersion === 'string';
+  const hasMetadata = typeof obj.metadata === 'object' && obj.metadata !== null;
+  const hasValidMetadata =
+    hasMetadata && Object.values(obj.metadata).every((value) => typeof value === 'string');
+  const hasCorrectType = obj['@type'] === EVALUATION_EVENT_NAME;
+
+  return (
+    isObject &&
+    hasTimestamp &&
+    hasFeatureId &&
+    hasFeatureVersion &&
+    hasUserId &&
+    hasVariationId &&
+    hasUser &&
+    hasReason &&
+    hasTag &&
+    hasSourceId &&
+    hasSdkVersion &&
+    hasMetadata &&
+    hasValidMetadata &&
+    hasCorrectType
+  );
+}

--- a/src/objects/goalEvent.ts
+++ b/src/objects/goalEvent.ts
@@ -34,3 +34,34 @@ export type GoalEvent = {
   metadata: { [key: string]: string };
   '@type': typeof GOAL_EVENT_NAME;
 };
+
+export function isGoalEvent(obj: any): obj is GoalEvent {
+  const isObject = typeof obj === 'object' && obj !== null;
+  const hasTimestamp = typeof obj.timestamp === 'number';
+  const hasGoalId = typeof obj.goalId === 'string';
+  const hasUserId = typeof obj.userId === 'string';
+  const hasValue = typeof obj.value === 'number';
+  const hasUser = obj.user === undefined || typeof obj.user === 'object';
+  const hasTag = typeof obj.tag === 'string';
+  const hasSourceId = obj.sourceId === SourceId.NODE_SERVER;
+  const hasSdkVersion = typeof obj.sdkVersion === 'string';
+  const hasMetadata = typeof obj.metadata === 'object' && obj.metadata !== null;
+  const hasValidMetadata =
+    hasMetadata && Object.values(obj.metadata).every((value) => typeof value === 'string');
+  const hasCorrectType = obj['@type'] === GOAL_EVENT_NAME;
+
+  return (
+    isObject &&
+    hasTimestamp &&
+    hasGoalId &&
+    hasUserId &&
+    hasValue &&
+    hasUser &&
+    hasTag &&
+    hasSourceId &&
+    hasSdkVersion &&
+    hasMetadata &&
+    hasValidMetadata &&
+    hasCorrectType
+  );
+}

--- a/src/objects/metricsEvent.ts
+++ b/src/objects/metricsEvent.ts
@@ -235,3 +235,26 @@ export const toErrorMetricsEvent = (e: any, tag: string, apiId: NodeApiIds): Eve
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return typeUtils.isNativeError(error);
 }
+
+export function isMetricsEvent(obj: any): obj is MetricsEvent {
+  const isObject = typeof obj === 'object' && obj !== null;
+  const hasTimestamp = typeof obj.timestamp === 'number';
+  const hasEvent = obj.event !== undefined;
+  const hasSourceId = obj.sourceId === SourceId.NODE_SERVER;
+  const hasSdkVersion = typeof obj.sdkVersion === 'string';
+  const hasMetadata = typeof obj.metadata === 'object' && obj.metadata !== null;
+  const hasValidMetadata =
+    hasMetadata && Object.values(obj.metadata).every((value) => typeof value === 'string');
+  const hasCorrectType = obj['@type'] === METRICS_EVENT_NAME;
+
+  return (
+    isObject &&
+    hasTimestamp &&
+    hasEvent &&
+    hasSourceId &&
+    hasSdkVersion &&
+    hasMetadata &&
+    hasValidMetadata &&
+    hasCorrectType
+  );
+}

--- a/src/objects/status.ts
+++ b/src/objects/status.ts
@@ -2,12 +2,12 @@ import { ApiId, NodeApiIds } from './apiId';
 import { createEvent } from './event';
 import { createMetricsEvent } from './metricsEvent';
 
+const FORBIDDEN_ERROR_METRICS_EVENT_NAME =
+  'type.googleapis.com/bucketeer.event.client.ForbiddenErrorMetricsEvent';
 const BAD_REQUEST_ERROR_METRICS_EVENT_NAME =
   'type.googleapis.com/bucketeer.event.client.BadRequestErrorMetricsEvent';
 const UNAUTHORIZED_ERROR_METRICS_EVENT_NAME =
   'type.googleapis.com/bucketeer.event.client.UnauthorizedErrorMetricsEvent';
-const FORBIDDEN_ERROR_METRICS_EVENT_NAME =
-  'type.googleapis.com/bucketeer.event.client.ForbiddenErrorMetricsEvent';
 const NOT_FOUND_ERROR_METRICS_EVENT_NAME =
   'type.googleapis.com/bucketeer.event.client.NotFoundErrorMetricsEvent';
 const CLIENT_CLOSED_REQUEST_ERROR_METRICS_EVENT_NAME =


### PR DESCRIPTION
# Change
- [x] Using BKTClientImpl class to implement the Bucketeer.
- [x] Rename `Client` to `APIClient` to prevent confusion. 
- [x] Add more metrics e2e tests 
- [x] Fix test fails with timeout error because the BKTClient has not destroyed 

Note: this PR didn't introduce breaking changes