### PR TITLE
chore: simplify objectVariation implementation by using objectVariationDetails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -212,13 +212,7 @@ export class BKTClientImpl implements Bucketeer {
   }
 
   async objectVariation(user: User, featureId: string, defaultValue: BKTValue): Promise<BKTValue> {
-    const valueStr = await this.stringVariation(user, featureId, '');
-    try {
-      return JSON.parse(valueStr);
-    } catch (e) {
-      this.config.logger?.debug('objectVariation failed to parse', e);
-      return defaultValue;
-    }
+    return (await this.objectVariationDetails(user, featureId, defaultValue)).variationValue;
   }
 
   async objectVariationDetails(


### PR DESCRIPTION
The `objectVariation` function has been altered as follows:

- Removed the logic that parses a string variation value to JSON and returns it, logging an error if parsing fails.
- Added a call to the `objectVariationDetails` function to get the variation value directly.

This change simplifies the implementation by delegating the variation retrieval to the `objectVariationDetails` method.