### PR TITLE
fix: flag not found when using dependency flag in targeting rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/node": "^22.13.7",
     "@types/uuid": "^10.0.0",
     "uuid": "^11.1.0",
-    "@bucketeer/evaluation": "0.0.1",
+    "@bucketeer/evaluation": "0.0.3",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "google-protobuf": "^3.21.4"

--- a/src/__tests__/client_assert_get_evaluation_rq.ts
+++ b/src/__tests__/client_assert_get_evaluation_rq.ts
@@ -1,8 +1,9 @@
 import anyTest, { TestFn } from 'ava';
-import { BKTClientImpl, Bucketeer, initialize } from '..';
+import { Bucketeer, initialize } from '..';
 import { Config, User } from '../bootstrap';
 import { DefaultLogger } from '../logger';
 import { newDefaultBKTEvaluationDetails } from '../evaluationDetails';
+import { BKTClientImpl } from '../client';
 
 const test = anyTest as TestFn<{
   bktClient: Bucketeer;

--- a/src/__tests__/evaluator/evaluator.ts
+++ b/src/__tests__/evaluator/evaluator.ts
@@ -69,6 +69,9 @@ test.beforeEach((t) => {
   segmentUsers2.setSegmentId('segment-id-2');
   segmentUsers2.setUsersList([sgUser2, sgUser3]);
 
+  const feature5Id = 'feature-id-5';
+  const feature5VariationFirstId = 'variation-true-id';
+
   const feature1 = createFeature({
     id: 'feature-id-1',
     version: 0,
@@ -146,6 +149,13 @@ test.beforeEach((t) => {
         operator: Clause.Operator.SEGMENT,
         values: [segmentUsers2.getSegmentId()],
       },
+      {
+        id: '',
+        attribute: feature5Id,
+        fixedVariation: '',
+        operator: Clause.Operator.FEATURE_FLAG,
+        values: [feature5VariationFirstId],
+      },
     ],
     variations: [
       {
@@ -203,7 +213,7 @@ test.beforeEach((t) => {
     tagList: ['server'],
     variations: [
       {
-        id: 'variation-true-id',
+        id: feature5VariationFirstId,
         name: 'true-name',
         value: 'true',
         description: 'variation-true-id',
@@ -432,11 +442,12 @@ test ('evaluate | success: with no prerequisites', async (t) => {
 
 test ('evaluate | success: with prerequisite feature disabled (It must return the off variation)', async (t) => {
   const { evaluator, featureFlagCache, segmentUsersCache, sandbox } = t.context;
-  const { feature3, feature4, segmentUser1, segmentUser2 } = t.context.data;
+  const { feature3, feature4, feature5, segmentUser1, segmentUser2 } = t.context.data;
   
   const featuresCacheMock = sandbox.mock(featureFlagCache);
   featuresCacheMock.expects('get').withArgs(feature3.getId()).resolves(feature3);
   featuresCacheMock.expects('get').withArgs(feature4.getId()).resolves(feature4);
+  featuresCacheMock.expects('get').withArgs(feature5.getId()).resolves(feature5);
 
   const segmentUsersCacheMock = sandbox.mock(segmentUsersCache);
   segmentUsersCacheMock.expects('get').withArgs(segmentUser1.getSegmentId()).resolves(segmentUser1);

--- a/src/__tests__/evaluator/evaluator.ts
+++ b/src/__tests__/evaluator/evaluator.ts
@@ -323,7 +323,7 @@ test('evaluate | err: get feature flag from cache | cache missing', async (t) =>
       },
       feature1.getId(),
     )
-    t.fail('Unexpected error was thrown');
+    t.fail('Expected error was not thrown');
   } catch (e) {
     t.deepEqual(e, new InvalidStatusError(`Feature not found: ${feature1.getId()}`, 404));
   }

--- a/src/__tests__/evaluator/protoReasonToReason.ts
+++ b/src/__tests__/evaluator/protoReasonToReason.ts
@@ -1,0 +1,89 @@
+import test from 'ava';
+import { protoReasonToReason } from '../../evaluator/local';
+import {
+  Reason as ProtoReason,
+} from '@bucketeer/evaluation';
+
+const testCases = [
+  {
+    input: undefined,
+    expected: { type: 'DEFAULT' },
+  },
+  {
+    input: {
+      getType: () => ProtoReason.Type.RULE,
+      getRuleId: () => 'rule-123',
+    } as ProtoReason,
+    expected: {
+      type: 'RULE',
+      ruleId: 'rule-123',
+    },
+  },
+  {
+    input: {
+      getType: () => ProtoReason.Type.TARGET,
+      getRuleId: () => 'rule-123',
+    } as ProtoReason,
+    expected: {
+      type: 'TARGET',
+      ruleId: 'rule-123',
+    },
+  },
+  {
+    input: {
+      getType: () => ProtoReason.Type.ERROR_EXCEPTION,
+      getRuleId: () => 'rule-123',
+    } as ProtoReason,
+    expected: {
+      type: 'DEFAULT',
+      ruleId: 'rule-123',
+    },
+  },
+  {
+    input: {
+      getType: () => ProtoReason.Type.DEFAULT,
+      getRuleId: () => 'rule-123',
+    } as ProtoReason,
+    expected: {
+      type: 'DEFAULT',
+      ruleId: 'rule-123',
+    },
+  },
+  {
+    input: {
+      getType: () => ProtoReason.Type.CLIENT,
+      getRuleId: () => 'rule-1235',
+    } as ProtoReason,
+    expected: {
+      type: 'CLIENT',
+      ruleId: 'rule-1235',
+    },
+  },
+  {
+    input: {
+      getType: () => ProtoReason.Type.OFF_VARIATION,
+      getRuleId: () => 'rule-1234',
+    } as ProtoReason,
+    expected: {
+      type: 'OFF_VARIATION',
+      ruleId: 'rule-1234',
+    },
+  },
+  {
+    input: {
+      getType: () => ProtoReason.Type.PREREQUISITE,
+      getRuleId: () => 'rule-1233',
+    } as ProtoReason,
+    expected: {
+      type: 'PREREQUISITE',
+      ruleId: 'rule-1233',
+    },
+  },
+];
+
+testCases.forEach(({ input, expected }, index) => {
+  test(`protoReasonToReason test case ${index + 1}`, (t) => {
+    const result = protoReasonToReason(input);
+    t.deepEqual(result, expected);
+  });
+});

--- a/src/evaluator/local.ts
+++ b/src/evaluator/local.ts
@@ -126,16 +126,18 @@ class LocalEvaluator implements NodeEvaluator {
   }
 
   async getTargetFeatures(feature: Feature): Promise<Feature[]> {
-    const targetFeatures: Feature[] = [feature];
     // Check if the flag depends on other flags.
-	  // If not, we return only the target flag
+    // If not, we return only the target flag
     const preFlagIDs = getFeatureIDsDependsOn(feature);
     if (preFlagIDs.length === 0) {
       return [feature];
     }
   
     const prerequisiteFeatures = await this.getPrerequisiteFeaturesFromCache(preFlagIDs);
-    return targetFeatures.concat(prerequisiteFeatures);
+    return [
+      feature,
+      ...prerequisiteFeatures,
+    ];
   }
 
   private async getPrerequisiteFeaturesFromCache(preFlagIDs: string[]): Promise<Feature[]> {

--- a/src/evaluator/local.ts
+++ b/src/evaluator/local.ts
@@ -6,7 +6,7 @@ import {
   SegmentUsers,
   UserEvaluations,
   Reason as ProtoReason,
-  Clause,
+  getFeatureIDsDependsOn,
 } from '@bucketeer/evaluation';
 
 import { FeaturesCache } from '../cache/features';
@@ -106,7 +106,7 @@ class LocalEvaluator implements NodeEvaluator {
     }
   }
 
-  private findEvaluation(userEvaluations: UserEvaluations, featureId: String): Evaluation {
+  findEvaluation(userEvaluations: UserEvaluations, featureId: String): Evaluation {
     for (const evaluation of userEvaluations.getEvaluationsList()) {
       if (evaluation.getFeatureId() === featureId) {
         return {
@@ -148,27 +148,6 @@ class LocalEvaluator implements NodeEvaluator {
   }
 } 
 
-// FeatureIDsDependsOn returns the ids of the features that this feature depends on.
-function getFeatureIDsDependsOn(feature: Feature): Array<string> {
-  const ids: Array<string> = [];
-
-  // Iterate over prerequisites and add their FeatureId
-  feature.getPrerequisitesList().forEach((p) => {
-    ids.push(p.getFeatureId());
-  });
-
-  // Iterate over rules and collect ids from clauses where the operator is FEATURE_FLAG
-  feature.getRulesList().forEach((rule) => {
-    rule.getClausesList().forEach((clause) => {
-      if (clause.getOperator() === Clause.Operator.FEATURE_FLAG) {
-        ids.push(clause.getAttribute());
-      }
-    });
-  });
-
-  return ids;
-}
-
 function protoReasonToReason(protoReason: ProtoReason | undefined): Reason {
   if (protoReason === undefined) {
     return {
@@ -200,4 +179,4 @@ function protoReasonTypeToReasonType(protoReasonType: number): ReasonType {
   }
 }
 
-export { LocalEvaluator };
+export { LocalEvaluator, protoReasonToReason };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,17 +1000,19 @@
   dependencies:
     google-protobuf "^3.6.1"
 
-"@bucketeer/evaluation@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@bucketeer/evaluation/-/evaluation-0.0.1.tgz#a1320e569be3a2548d103e62013a8b0be9ded75c"
-  integrity sha512-i2IAt2N5Zl2KVg3YrCLkjOZaDZCB0cqmk5G7tXBU+21V743e8dRP9J10y4Q3lTukOCIMtOh873IJMamd+1i6Ew==
+"@bucketeer/evaluation@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@bucketeer/evaluation/-/evaluation-0.0.3.tgz#ce0c2c8d2102ee569c85d8f230d3ccc0b4898ced"
+  integrity sha512-WXFv0kis0M28bRwPJW0t3CgKPU7G8FJUW3A0m6Fwfej/CxfSqRSKZp2fWcK3zYBhU9fvSw64zYjriH0j8suKUQ==
   dependencies:
     "@improbable-eng/grpc-web" "^0.15.0"
     "@types/fnv-plus" "^1.3.2"
     "@types/google-protobuf" "^3.15.12"
+    "@types/murmurhash3js" "^3.0.7"
     "@types/semver" "^7.5.8"
     fnv-plus "^1.3.1"
     google-protobuf "3.14.0"
+    murmurhash3js "^3.0.1"
 
 "@bundled-es-modules/cookie@^2.0.1":
   version "2.0.1"
@@ -1507,6 +1509,11 @@
   version "7.0.15"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
+"@types/murmurhash3js@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/murmurhash3js/-/murmurhash3js-3.0.7.tgz#5c3589180f13aac082857932ffb353251e7f296b"
+  integrity sha512-jN3Z37nILIW1DZyP6N/NK+aw/zjFHPVb7hjrmdw7jx7FayrhKgkNpo6ZDwAsH8HSANjebBOxoXXtA39gKwyeGw==
 
 "@types/node-fetch@2.6.12":
   version "2.6.12"
@@ -4374,6 +4381,11 @@ msw@^2.7.3:
     strict-event-emitter "^0.5.1"
     type-fest "^4.26.1"
     yargs "^17.7.2"
+
+murmurhash3js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/murmurhash3js/-/murmurhash3js-3.0.1.tgz#3e983e5b47c2a06f43a713174e7e435ca044b998"
+  integrity sha512-KL8QYUaxq7kUbcl0Yto51rMcYt7E/4N4BG3/c96Iqw1PQrTRspu8Cpx4TZ4Nunib1d4bEkIH3gjCYlP2RLBdow==
 
 mute-stream@0.0.8:
   version "0.0.8"


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/1552

Refers to https://github.com/bucketeer-io/go-server-sdk/pull/157/files

This pull request includes several changes to improve the evaluation process and testing in the project. The most important changes include updating dependencies, refactoring test cases, and enhancing the `LocalEvaluator` class.

### Dependency updates:
* Updated the version of `@bucketeer/evaluation` from `0.0.1` to `0.0.3` in the `package.json` file.

### Test improvements:
* Refactored imports in `src/__tests__/client_assert_get_evaluation_rq.ts` to directly import `BKTClientImpl` from `client`.
* Added new test cases for `protoReasonToReason` function in `src/__tests__/evaluator/protoReasonToReason.ts`.
* Modified multiple test cases in `src/__tests__/evaluator/evaluator.ts` to use `try-catch` blocks instead of `.catch` for error handling. [[1]](diffhunk://#diff-1c80d2dc4e634a3dd5b49a71829af9581565654b6c37bf3227f345af9a5ef915R294) [[2]](diffhunk://#diff-1c80d2dc4e634a3dd5b49a71829af9581565654b6c37bf3227f345af9a5ef915R316-R317) [[3]](diffhunk://#diff-1c80d2dc4e634a3dd5b49a71829af9581565654b6c37bf3227f345af9a5ef915R343) [[4]](diffhunk://#diff-1c80d2dc4e634a3dd5b49a71829af9581565654b6c37bf3227f345af9a5ef915R371) [[5]](diffhunk://#diff-1c80d2dc4e634a3dd5b49a71829af9581565654b6c37bf3227f345af9a5ef915R401)
**Their tests will fail if the expected error is not throw**

* Added new test cases for `getTargetFeatures`, `findEvaluation`, and `getTargetFeatures` methods in `src/__tests__/evaluator/evaluator.ts`.

### Enhancements to `LocalEvaluator` class:
* Modified the `findEvaluation` method to be public.
* Refactored the `getTargetFeatures` method to handle prerequisite features more efficiently.
* Added a new private method `getPrerequisiteFeaturesFromCache` to replace `getPrerequisiteFeatures`.
* Exported `protoReasonToReason` function from `src/evaluator/local.ts`.