### PR TITLE
build(deps): update @bucketeer/evaluation to v0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@types/node": "^22.15.35",
-    "@types/uuid": "^10.0.0",
     "uuid": "^11.1.0",
-    "@bucketeer/evaluation": "0.0.5",
+    "@bucketeer/evaluation": "0.0.6",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "google-protobuf": "^3.21.4"
@@ -52,6 +50,8 @@
     "terser": "5.43.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.41.0",
-    "uglify-es": "3.3.9"
+    "uglify-es": "3.3.9",
+    "@types/node": "^22.15.35",
+    "@types/uuid": "^10.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,10 +1015,10 @@
   dependencies:
     google-protobuf "^3.6.1"
 
-"@bucketeer/evaluation@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@bucketeer/evaluation/-/evaluation-0.0.5.tgz#5e0a9e181cc09fe3b2ec231c0b51d91e9ba5b85a"
-  integrity sha512-qZf/wh7hXdS3IBV0TmmXKbNBfbvg5/Clrb7hTryEAdihp5zsimEo9JYiCZ17x8sCKEKd8d7nMb4+gNl35mpTYw==
+"@bucketeer/evaluation@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@bucketeer/evaluation/-/evaluation-0.0.6.tgz#28a2a3271f0a256661450eb8b0227147519495bf"
+  integrity sha512-Ve7e81Lz6INrpa8dxhEzaUz3fXN5jQGQE1K4Vj88l+NarNst/ksmvEiqYkhrH1tHjszd7TxCir9tTTGg8VLWqQ==
   dependencies:
     "@improbable-eng/grpc-web" "^0.15.0"
     "@types/fnv-plus" "^1.3.2"
@@ -1027,6 +1027,7 @@
     "@types/semver" "^7.5.8"
     fnv-plus "^1.3.1"
     google-protobuf "3.14.0"
+    js-yaml "^4.1.0"
     murmurhash3js "^3.0.1"
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.7.0":


### PR DESCRIPTION
Upgraded @bucketeer/evaluation from version 0.0.5 to 0.0.6 in dependencies. Moved @types/node and @types/uuid from dependencies to devDependencies for better package organization.