### PR TITLE
chore: add local evaluation example and start-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ make start
 Update `example/src/index-local-evaluation.ts`, then run:
 
 ```bash
-make start-local
+make start-local-evaluation
 ```
 
 If you want to use a published SDK instead of a local one, replace the line where it imports the library in the [example code](https://github.com/bucketeer-io/node-server-sdk/blob/master/example/src/index.ts#L7-L8)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are two example entry points:
 - `example/src/index.ts`: Remote evaluation example.
 - `example/src/index-local-evaluation.ts`: Local evaluation example with `enableLocalEvaluation: true`.
 
-Use the local evaluation example when you want to evaluate users within SDK locally. 
+Use the local evaluation example when you want to evaluate users locally within the SDK.
 
 Use the remote evaluation example when you want to evaluate users on the Bucketeer service side.
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,35 @@ Please follow our contribution guide [here](https://docs.bucketeer.io/contributi
 Before building the example, please follow the following steps.
 
 - Ensure that you have the `yarn` installed.
-- Configure the `apiEndpoint` (with URL scheme like `https://`) and the `apiKey` info in the [index.ts](https://github.com/bucketeer-io/node-server-sdk/blob/master/example/src/index.ts#L15-L19).
+- Configure the `apiEndpoint` (with URL scheme like `https://`) and the `apiKey` in the example source file you want to run.
 - Move to the example directory `cd example`.
 - Install dependencies `make init`.
 
-### Build and start an example server
+### Build and start the example server
+
+There are two example entry points:
+
+- `example/src/index.ts`: Remote evaluation example.
+- `example/src/index-local-evaluation.ts`: Local evaluation example with `enableLocalEvaluation: true`.
+
+Use the local evaluation example when you want to evaluate users within SDK locally. 
+
+Use the remote evaluation example when you want to evaluate users on the Bucketeer service side.
+
+#### Remote evaluation
+
+Update `example/src/index.ts`, then run:
 
 ```bash
 make start
+```
+
+#### Local evaluation
+
+Update `example/src/index-local-evaluation.ts`, then run:
+
+```bash
+make start-local
 ```
 
 If you want to use a published SDK instead of a local one, replace the line where it imports the library in the [example code](https://github.com/bucketeer-io/node-server-sdk/blob/master/example/src/index.ts#L7-L8)

--- a/example/Makefile
+++ b/example/Makefile
@@ -10,7 +10,7 @@ start: build-sdk build
 	node $(CURDIR)/__build/index.js
 
 .PHONY: start-local-evaluation
-start-local: build-sdk build
+start-local-evaluation: build-sdk build
 	node $(CURDIR)/__build/index-local-evaluation.js
 
 .PHONY: clean

--- a/example/Makefile
+++ b/example/Makefile
@@ -9,6 +9,10 @@ init:
 start: build-sdk build
 	node $(CURDIR)/__build/index.js
 
+.PHONY: start-local-evaluation
+start-local: build-sdk build
+	node $(CURDIR)/__build/index-local-evaluation.js
+
 .PHONY: clean
 clean:
 	rm -rf $(CURDIR)/__build

--- a/example/src/index-local-evaluation.ts
+++ b/example/src/index-local-evaluation.ts
@@ -33,8 +33,8 @@ const html = ({ label }: { label: string }) => `
     <body>
       <button id=btn type="button">${label}</button>
       <script>
-      async function butotnClick(event){
-          const response = await fetch('http://localhost:3000', {
+      async function buttonClick(event){
+          const response = await fetch('/', {
             method: 'POST',
             mode: 'cors',
             cache: 'no-cache',
@@ -49,7 +49,7 @@ const html = ({ label }: { label: string }) => `
           console.log(text);
       }
       let button = document.getElementById('btn');
-      button.addEventListener('click', function (e) { butotnClick(e) });
+      button.addEventListener('click', function (e) { buttonClick(e) });
       </script>
     </body>
   </html>
@@ -73,7 +73,7 @@ async function start() {
     console.log('Bucketeer SDK initialized successfully');
 
     /**
-     *  Useful for trouble shooting.
+     *  Useful for troubleshooting.
      */
     console.table(bucketeer.getBuildInfo());
 

--- a/example/src/index-local-evaluation.ts
+++ b/example/src/index-local-evaluation.ts
@@ -1,0 +1,137 @@
+import express from 'express';
+
+/* webpackChunkName: "bucketeer" */
+
+// NOTE: If you want to use SDK published on npm,
+// replace the line below with the following.
+// import { initialize } from '@bucketeer/node-server-sdk';
+import { initializeBKTClient, defineBKTConfig } from '../../lib';
+
+const PORT = 3000;
+const SHUTDOWN_TIMEOUT = 30000;
+
+/**
+ *  Initialize bucketeer.
+ */
+const config = defineBKTConfig({
+  apiEndpoint: '<API_ENDPOINT>', // e.g. https://api-media.bucketeer.jp or api-media.bucketeer.jp
+  apiKey: '<TOKEN>', // SERVER ROLE API KEY
+  featureTag: 'nodejs',
+  enableLocalEvaluation: true,
+  // scheme: 'http', // Optional: explicitly set scheme for local development (defaults to 'https')
+});
+const bucketeer = initializeBKTClient(config);
+
+const html = ({ label }: { label: string }) => `
+  <!doctype html>
+  <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <title>bucketeer web-server-sdk example</title>
+    </head>
+    <body>
+      <button id=btn type="button">${label}</button>
+      <script>
+      async function butotnClick(event){
+          const response = await fetch('http://localhost:3000', {
+            method: 'POST',
+            mode: 'cors',
+            cache: 'no-cache',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            redirect: 'follow',
+            referrerPolicy: 'no-referrer',
+            body: JSON.stringify({value: 1})
+          })
+          const text = await response.text();
+          console.log(text);
+      }
+      let button = document.getElementById('btn');
+      button.addEventListener('click', function (e) { butotnClick(e) });
+      </script>
+    </body>
+  </html>
+`;
+
+const controller = (_: express.Request, res: express.Response, next: express.NextFunction) => {
+  (async () => {
+    const label = await bucketeer.stringVariation(
+      { id: 'uid', data: {} },
+      'node-server-debug',
+      'defaultValue',
+    );
+    res.send(html({ label }));
+  })().catch(next);
+};
+
+async function start() {
+  try {
+    console.log('Waiting for Bucketeer SDK to initialize...');
+    await bucketeer.waitForInitialization({ timeout: 5000 });
+    console.log('Bucketeer SDK initialized successfully');
+
+    /**
+     *  Useful for trouble shooting.
+     */
+    console.table(bucketeer.getBuildInfo());
+
+    const app = express();
+
+    app.use(express.urlencoded({ extended: true }));
+    app.use(express.json());
+
+    app.get('/', controller);
+
+    app.post('/', (req, res) => {
+      bucketeer.track({ id: 'uid', data: {} }, 'goal-debug', req.body.value);
+      res.status(200).send('Track is called.');
+    });
+
+    const server = app.listen(PORT, () => {
+      console.log(`App listening on port ${PORT}`);
+    });
+
+    /**
+     * Graceful shutdown handler
+     * This ensures all events are flushed before the process exits
+     */
+    const gracefulShutdown = async (signal: string) => {
+      console.log(`\n${signal} received, starting graceful shutdown...`);
+      server.close(async () => {
+        console.log('HTTP server closed');
+        try {
+          /**
+           * IMPORTANT: Always call destroy() before your application exits
+           * This flushes all remaining events to the server and stops background workers
+           */
+          await bucketeer.destroy();
+          console.log('Bucketeer SDK shutdown complete');
+          console.log('Graceful shutdown completed');
+          process.exit(0);
+        } catch (error) {
+          console.error('Error during shutdown:', error);
+          process.exit(1);
+        }
+      });
+
+      // Force exit if graceful shutdown takes too long (30 seconds)
+      setTimeout(() => {
+        console.error('Graceful shutdown timeout, forcing exit');
+        process.exit(1);
+      }, SHUTDOWN_TIMEOUT);
+    };
+
+    // Handle SIGTERM (Docker, Kubernetes, systemd)
+    process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+
+    // Handle SIGINT (Ctrl+C)
+    process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+  } catch (e) {
+    console.error('Failed to initialize bucketeer sdk', e);
+    process.exit(1);
+  }
+}
+
+start();

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -22,7 +22,7 @@ const config = defineBKTConfig({
 const bucketeer = initializeBKTClient(config);
 
 /**
- *  Useful for trouble shooting.
+ *  Useful for troubleshooting.
  */
 console.table(bucketeer.getBuildInfo());
 
@@ -37,8 +37,8 @@ const html = ({ label }: { label: string }) => `
     <body>
       <button id=btn type="button">${label}</button>
       <script>
-      async function butotnClick(event){
-          const response = await fetch('http://localhost:3000', {
+      async function buttonClick(event){
+          const response = await fetch('/', {
             method: 'POST',
             mode: 'cors',
             cache: 'no-cache',
@@ -53,7 +53,7 @@ const html = ({ label }: { label: string }) => `
           console.log(text);
       }
       let button = document.getElementById('btn');
-      button.addEventListener('click', function (e) { butotnClick(e) });
+      button.addEventListener('click', function (e) { buttonClick(e) });
       </script>
     </body>
   </html>


### PR DESCRIPTION
This pull request adds a new example for local feature flag evaluation and improves the documentation and developer experience for running examples. The main changes include introducing a local evaluation example entry point, updating the `Makefile` to support it, and enhancing the `README.md` with clearer instructions.

**Example enhancements:**

* Added a new example entry point `example/src/index-local-evaluation.ts` that demonstrates how to use the SDK with `enableLocalEvaluation: true`, including a simple Express server and graceful shutdown logic.
* Updated the `Makefile` to add a `start-local` command for running the local evaluation example.

**Documentation improvements:**

* Revised the `README.md` to clearly explain the difference between remote and local evaluation examples, how to configure and run each, and which entry point to use.