### PR TITLE
test(e2e): load secret from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+API_ENDPOINT=your.api.endpoint
+SCHEME=https
+CLIENT_API_KEY=your-client-key
+SERVER_API_KEY=your-server-key

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,17 +47,8 @@ jobs:
         run: make build
       - name: e2e test
         run: |
-          API_ENDPOINT="${{ secrets.E2E_API_ENDPOINT }}"
-          SCHEME="${{ secrets.E2E_SCHEME }}"
-          if [ -z "$SCHEME" ]; then
-            SCHEME="https"
-          fi
-          CLIENT_API_KEY="${{ secrets.E2E_CLIENT_API_KEY }}"
-          SERVER_API_KEY="${{ secrets.E2E_SERVER_API_KEY }}"
-
-          sed -i -e "s|<API_ENDPOINT>|${API_ENDPOINT}|" \
-            -e "s|<SCHEME>|${SCHEME}|" \
-            -e "s|<CLIENT_API_KEY>|${CLIENT_API_KEY}|" \
-            -e "s|<SERVER_API_KEY>|${SERVER_API_KEY}|" \
-            ava-e2e.config.mjs
+          echo "API_ENDPOINT=${{ secrets.E2E_API_ENDPOINT }}" > .env
+          echo "SCHEME=${{ secrets.E2E_SCHEME || 'https' }}" >> .env
+          echo "CLIENT_API_KEY=${{ secrets.E2E_CLIENT_API_KEY }}" >> .env
+          echo "SERVER_API_KEY=${{ secrets.E2E_SERVER_API_KEY }}" >> .env
           make e2e

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __test
 __e2e
 lib
 .vscode/launch.json
+.env

--- a/README.md
+++ b/README.md
@@ -83,9 +83,28 @@ make build
 make test
 ```
 
+
 #### Run e2e tests
 
-Configure the `apiEndpoint` (with URL scheme) and the `apiKey` info in the [ava-e2e.config.mjs](./ava-e2e.config.mjs), then run the following command.
+Set the required secrets for E2E tests using environment variables or a `.env` file in the project root. The following variables are required:
+
+- `API_ENDPOINT` (e.g. api.example.com, without scheme)
+- `SCHEME` (e.g. https or http, defaults to https)
+- `CLIENT_API_KEY` (Client SDK role API key)
+- `SERVER_API_KEY` (Server SDK role API key for testing with local evaluate)
+
+You can create a `.env` file in the project root for local development:
+
+```
+API_ENDPOINT=your.api.endpoint
+SCHEME=https
+CLIENT_API_KEY=your-client-key
+SERVER_API_KEY=your-server-key
+```
+
+The E2E test config will automatically load these values.
+
+Then run:
 
 ```bash
 make e2e

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ make test
 
 #### Run e2e tests
 
-Set the required secrets for E2E tests using environment variables or a `.env` file in the project root. The following variables are required:
+Set the required secrets for E2E tests using environment variables or a `.env` file in the project root. The following variables are required, except for `SCHEME`, which is optional and defaults to `https`:
 
 - `API_ENDPOINT` (e.g. api.example.com, without scheme)
-- `SCHEME` (e.g. https or http, defaults to https)
+- `SCHEME` (optional; e.g. https or http, defaults to https)
 - `CLIENT_API_KEY` (Client SDK role API key)
 - `SERVER_API_KEY` (Server SDK role API key for testing with local evaluate)
 

--- a/ava-e2e.config.mjs
+++ b/ava-e2e.config.mjs
@@ -1,3 +1,5 @@
+import 'dotenv/config'; // Loads .env file into process.env
+
 export default {
   babel: {
     testOptions: {
@@ -10,9 +12,9 @@ export default {
     '__e2e/__test__/local_evaluation/*.js'
   ],
   environmentVariables: {
-    API_ENDPOINT: '<API_ENDPOINT>', // replace this. e.g. api.example.com (without scheme)
-    SCHEME: '<SCHEME>', // replace this. e.g. https or http (defaults to https)
-    CLIENT_API_KEY: '<CLIENT_API_KEY>', // replace this. Client SDK role API key
-    SERVER_API_KEY: '<SERVER_API_KEY>', // replace this. Server SDK role API key for testing with local evaluate
+    API_ENDPOINT: process.env.API_ENDPOINT || '<API_ENDPOINT>', // e.g. api.example.com (without scheme)
+    SCHEME: process.env.SCHEME || '<SCHEME>', // e.g. https or http (defaults to https)
+    CLIENT_API_KEY: process.env.CLIENT_API_KEY || '<CLIENT_API_KEY>', // Client SDK role API key
+    SERVER_API_KEY: process.env.SERVER_API_KEY || '<SERVER_API_KEY>', // Server SDK role API key for testing with local evaluate
   },
 };

--- a/ava-e2e.config.mjs
+++ b/ava-e2e.config.mjs
@@ -11,10 +11,4 @@ export default {
     '__e2e/__test__/*.js',
     '__e2e/__test__/local_evaluation/*.js'
   ],
-  environmentVariables: {
-    API_ENDPOINT: process.env.API_ENDPOINT || '<API_ENDPOINT>', // e.g. api.example.com (without scheme)
-    SCHEME: process.env.SCHEME || '<SCHEME>', // e.g. https or http (defaults to https)
-    CLIENT_API_KEY: process.env.CLIENT_API_KEY || '<CLIENT_API_KEY>', // Client SDK role API key
-    SERVER_API_KEY: process.env.SERVER_API_KEY || '<SERVER_API_KEY>', // Server SDK role API key for testing with local evaluate
-  },
 };

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {
-    "uuid": "^11.1.0",
     "@bucketeer/evaluation": "0.0.7",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
-    "google-protobuf": "^3.21.4"
+    "google-protobuf": "^3.21.4",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@ava/babel": "2.0.0",
@@ -30,13 +30,15 @@
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-replace": "^6.0.3",
     "@types/eslint": "^9.6.1",
+    "@types/node": "^22.15.35",
     "@types/node-fetch": "2.6.13",
+    "@types/sinon": "^17.0.4",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.46.3",
     "@typescript-eslint/parser": "^8.46.3",
     "ava": "6.4.1",
-    "@types/sinon": "^17.0.4",
-    "sinon": "^21.0.0",
     "cpx": "1.5.0",
+    "dotenv": "^17.4.2",
     "eslint": "^9.34.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.5",
@@ -47,11 +49,10 @@
     "replace": "1.2.2",
     "rollup": "^4.50.2",
     "semver": "7.7.4",
+    "sinon": "^21.0.0",
     "terser": "5.46.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.41.0",
-    "uglify-es": "3.3.9",
-    "@types/node": "^22.15.35",
-    "@types/uuid": "^10.0.0"
+    "uglify-es": "3.3.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3004,6 +3004,11 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^17.4.2:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.4.2.tgz#c07e54a746e11eba021dd9e1047ced5afdc1c034"
+  integrity sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==
+
 dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz"


### PR DESCRIPTION
This pull request updates how environment variables are managed for E2E (end-to-end) tests by switching from hardcoded configuration in the test config file to using a `.env` file and the `dotenv` package. It also updates the documentation to reflect these changes and makes some minor adjustments to dependencies in `package.json`.

fix https://github.com/bucketeer-io/node-server-sdk/issues/193