### PR TITLE
chore: optimize http timeout and flush interval for server-side usage

### DIFF
--- a/src/__tests__/convert_config_to_bkt_config.ts
+++ b/src/__tests__/convert_config_to_bkt_config.ts
@@ -16,7 +16,7 @@ test('should convert Config to BKTConfig with defaults', (t) => {
   t.is(bktConfig.apiKey, 'test-token');
   t.is(bktConfig.apiEndpoint, 'https://api.example.com');
   t.is(bktConfig.featureTag, 'test-tag');
-  t.is(bktConfig.eventsFlushInterval, 10000); // Default value
+  t.is(bktConfig.eventsFlushInterval, 30000); // Default value
   t.is(bktConfig.eventsMaxQueueSize, 50); // Default value
   t.is(bktConfig.cachePollingInterval, 60000); // Default value
   t.is(bktConfig.appVersion, '1.0.0'); // Default value

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -86,7 +86,7 @@ export class APIClient {
         'Content-Type': 'application/json',
         authorization: this.apiKey,
       },
-      timeout: 10000,
+      timeout: 5000,
     };
     return new Promise((resolve, reject) => {
       const clientReq = https.request(url, opts, (res) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,7 +138,7 @@ interface BKTConfig {
 // MINIMUM_FLUSH_INTERVAL_MILLIS and DEFAULT_FLUSH_INTERVAL_MILLIS are currently set to the same value (10 seconds).
 // They are defined separately in case their values need to diverge in the future.
 const MINIMUM_FLUSH_INTERVAL_MILLIS = 10_000; // 10 seconds
-const DEFAULT_FLUSH_INTERVAL_MILLIS = 10_000; // 10 seconds
+const DEFAULT_FLUSH_INTERVAL_MILLIS = 30_000; // 30 seconds
 const DEFAULT_MAX_QUEUE_SIZE = 50;
 const MINIMUM_POLLING_INTERVAL_MILLIS = 60_000; // 60 seconds
 const DEFAULT_POLLING_INTERVAL_MILLIS = 60_000; // 60 seconds
@@ -206,6 +206,11 @@ const defineBKTConfig = (config: Partial<BKTConfig>): BKTConfig => {
   }
 
   // Validate eventsFlushInterval
+  //
+  // Note: The SDK enforces a deadline of 80% of the flush interval for retry operations.
+  // Very short intervals (e.g., <20s) may limit the number of actual retry attempts
+  // if requests fail, even when MaxRetries is set to 3. However, failed events are
+  // automatically re-queued and will be retried in the next flush cycle.
   if (baseConfig.eventsFlushInterval < MINIMUM_FLUSH_INTERVAL_MILLIS) {
     baseConfig.logger?.warn?.(
       `eventsFlushInterval (${baseConfig.eventsFlushInterval}) is less than the minimum allowed (${MINIMUM_FLUSH_INTERVAL_MILLIS}). Using default value (${DEFAULT_FLUSH_INTERVAL_MILLIS}).`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,8 +135,8 @@ interface BKTConfig {
   wrapperSdkSourceId?: number;
 }
 
-// MINIMUM_FLUSH_INTERVAL_MILLIS and DEFAULT_FLUSH_INTERVAL_MILLIS are currently set to the same value (10 seconds).
-// They are defined separately in case their values need to diverge in the future.
+// The minimum flush interval is 10 seconds, while the default flush interval is 30 seconds.
+// They are defined separately because the default must not be lower than the enforced minimum.
 const MINIMUM_FLUSH_INTERVAL_MILLIS = 10_000; // 10 seconds
 const DEFAULT_FLUSH_INTERVAL_MILLIS = 30_000; // 30 seconds
 const DEFAULT_MAX_QUEUE_SIZE = 50;


### PR DESCRIPTION
refs: https://github.com/bucketeer-io/go-server-sdk/pull/190

# Summary
Optimizes timeout and flush interval defaults for server-to-server communication.

# Changes
HTTP timeout: 10s → 5s
Default flush interval: 10s → 30s
Added docs about retry behavior with custom intervals

**5s timeout:** Server-to-server requests are fast (RegisterEvents p95: 1-2s). With retry logic, fast failure is better than waiting 10s on stalled connections.

**30s flush interval:** Reduces API load 3× while maintaining proper retry coverage. Server-side SDKs run continuously (unlike browser SDKs where users close tabs), so 30s latency is acceptable for analytics.

**Interaction:** With 5s timeout + 30s flush (24s deadline), all 3 retry attempts fit: 5s + 1s + 5s + 2s + 5s = 18s ✅
Users can still configure shorter intervals if needed. Failed events are automatically re-queued.

