### PR TITLE
ci: fix correct secret names passed to reusable e2e workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,8 +125,8 @@ jobs:
     needs: install-dependencies
     uses: ./.github/workflows/e2e.yml
     secrets:
-      E2E_HOST: ${{ secrets.E2E_HOST }}
-      E2E_TOKEN: ${{ secrets.E2E_TOKEN }}
-      E2E_SERVER_ROLE_TOKEN: ${{ secrets.E2E_SERVER_ROLE_TOKEN }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN}}
+      E2E_API_ENDPOINT: ${{ secrets.E2E_API_ENDPOINT }}
+      E2E_CLIENT_API_KEY: ${{ secrets.E2E_CLIENT_API_KEY }}
+      E2E_SERVER_API_KEY: ${{ secrets.E2E_SERVER_API_KEY }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
fix https://github.com/bucketeer-io/node-server-sdk/actions/runs/26619299937

## Error 
```
The workflow is not valid. .github/workflows/build.yml (Line: 126, Col: 11): Secret E2E_API_ENDPOINT is required, but not provided while calling. .github/workflows/build.yml (Line: 126, Col: 11): Secret E2E_CLIENT_API_KEY is required, but not provided while calling.
```

The error was first seen in https://github.com/bucketeer-io/node-server-sdk/actions/runs/19558608373

## Problem

The build.yml caller workflow was passing secrets under the wrong keys when invoking the reusable e2e.yml workflow:

```
Secret E2E_API_ENDPOINT is required, but not provided while calling.
Secret E2E_CLIENT_API_KEY is required, but not provided while calling.
```

This happened because the secrets block in build.yml used legacy/inconsistent names (`E2E_HOST`, `E2E_TOKEN`, `E2E_SERVER_ROLE_TOKEN`) that do not match the `secrets:` declarations in e2e.yml. GitHub Actions validates secret names at parse time for `workflow_call`, so the workflow was rejected before any job ran.

## Fix

Updated the `secrets` block in the e2e job of build.yml to pass the correct keys that match the reusable workflow's declared interface:

| Before | After |
|---|---|
| `E2E_HOST` | `E2E_API_ENDPOINT` |
| `E2E_TOKEN` | `E2E_CLIENT_API_KEY` |
| `E2E_SERVER_ROLE_TOKEN` | `E2E_SERVER_API_KEY` |

No changes were made to e2e.yml — it was already correct.
